### PR TITLE
Possibility to create own data snapshot convertion function

### DIFF
--- a/app/src/main/java/com/example/matteo/firebase_recycleview/MyAdapter.java
+++ b/app/src/main/java/com/example/matteo/firebase_recycleview/MyAdapter.java
@@ -30,9 +30,9 @@ public class MyAdapter extends FirebaseRecyclerAdapter<MyAdapter.ViewHolder, MyI
         }
     }
 
-    public MyAdapter(Query query, Class<MyItem> itemClass, @Nullable ArrayList<MyItem> items,
+    public MyAdapter(Query query, @Nullable ArrayList<MyItem> items,
                      @Nullable ArrayList<String> keys) {
-        super(query, itemClass, items, keys);
+        super(query, items, keys);
     }
 
     @Override public MyAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {


### PR DESCRIPTION
Hi, I did some changes to make your class fits for those who also don't know the specific type will be got from the data snapshot. For those cases, it's better let the developer implements the own algorithm for it. In my case, I can't use `dataSnapshot.getValue(mItemClass)` to get the object instance because I don't know who is the mItemClass in develop time. So I created the protected `getConvertedObject(datasnapshot)`, that could be overrided by the subclass.

Also, there's no need of mItemClass, once you know it by generic T. Look `getGenericClass()`.